### PR TITLE
Getstream patch starscream minor update

### DIFF
--- a/Faye/Client.swift
+++ b/Faye/Client.swift
@@ -187,6 +187,9 @@ extension Client: WebSocketDelegate {
             isWebSocketConnected = false
             log("❌ WS Disconnect with error: \(error)")
             //handleError(error)
+        case .peerClosed:
+            isWebSocketConnected = false
+            log("❌ WS Disconnect: Connection closed")
         }
     }
 }

--- a/Faye/Client.swift
+++ b/Faye/Client.swift
@@ -141,7 +141,7 @@ extension Client {
 // MARK: - Connection
 
 extension Client: WebSocketDelegate {
-    public func didReceive(event: WebSocketEvent, client: WebSocket) {
+    public func didReceive(event: WebSocketEvent, client: WebSocketClient) {
         switch event {
         case .connected(let headers):
             isWebSocketConnected = true


### PR DESCRIPTION
# Submit a pull request

GetStream went broken since 2 days ago, since starscream developers updated the library including a new enum case `WebSocketEvent` in `4.0.X` version of the library [(find here)](https://github.com/daltoniam/Starscream/commit/f900d67759cdd11df3dcca34af21f40f59fe4e79#diff-2e4514a7ad13578f9c9cf7eb587e1ac4f93726c89e6e24fccc416b12deb24f0fR52), that change broke the `Client` object conformance to `WebSocketDelegate` protocol, being not able to compile the project anymore facing following build error while compiling:

<img width="1512" alt="Screenshot 2023-08-21 at 15 40 54" src="https://github.com/mohamadrezakoohkan/stream-swift/assets/37219076/8781435e-49f4-40ca-8fda-9f1358f60882">

Proposed solution in this PR includes this new enum case and updates the delegate method inputs to receive an abstraction of `WebSocket` as same as they have defined like `WebSocketClient` to avoid following error:
> Type 'Client' does not conform to protocol 'WebSocketDelegate'

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) with my github username (required). 
- [ ] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

